### PR TITLE
fixed typo

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1356,7 +1356,7 @@
             /**
              * List of currencies
              *
-             * List of all currencies, including currency symol, name, plural, and decimal
+             * List of all currencies, including currency symbol, name, plural, and decimal
              * digits for all major and minor currencies. You can use the locale header to
              * get the data in supported language.
              *


### PR DESCRIPTION
Fixed typo `symol` -> `symbol` :)
My samll contribution to the environment.